### PR TITLE
Pin version of VM2 to version w/o vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@nlpjs/nlu": "^4.4.0",
     "@nlpjs/request": "^4.4.0",
     "@nlpjs/sentiment": "^4.4.0",
-    "vm2": "3.9.3"
+    "vm2": "3.9.11"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Upgrades version of VM2 to a version that fixes the 'Sandbreak' vulnerability: https://www.darkreading.com/application-security/critical-open-source-vm2-sandbox-escape-bug-affects-millions