### PR TITLE
Pin version of VM2 to 3.9.17 without vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@nlpjs/nlu": "^4.4.0",
     "@nlpjs/request": "^4.4.0",
     "@nlpjs/sentiment": "^4.4.0",
-    "vm2": "3.9.11"
+    "vm2": "3.9.17"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Upgrades version of VM2 to a version that fixes vulnerability: https://www.bleepingcomputer.com/news/security/exploit-available-for-critical-bug-in-vm2-javascript-sandbox-library/ 