### PR TITLE
Only load english

### DIFF
--- a/nlp/index.js
+++ b/nlp/index.js
@@ -24,7 +24,7 @@
 const fs = require('fs')
 const { containerBootstrap } = require('@nlpjs/core-loader')
 const { Language } = require('@nlpjs/language')
-const { LangEn } = require('@nlpjs/lang-en');
+const { LangEn } = require('@nlpjs/lang-en')
 const { Nlp } = require('@nlpjs/nlp')
 const { Evaluator, Template } = require('@nlpjs/evaluator')
 const { fs: requestfs } = require('@nlpjs/request')

--- a/nlp/index.js
+++ b/nlp/index.js
@@ -24,7 +24,7 @@
 const fs = require('fs')
 const { containerBootstrap } = require('@nlpjs/core-loader')
 const { Language } = require('@nlpjs/language')
-const { LangAll } = require('@nlpjs/lang-all')
+const { LangEn } = require('@nlpjs/lang-en');
 const { Nlp } = require('@nlpjs/nlp')
 const { Evaluator, Template } = require('@nlpjs/evaluator')
 const { fs: requestfs } = require('@nlpjs/request')
@@ -43,7 +43,7 @@ class NlpManager {
     })
     this.container.register('fs', requestfs)
     this.container.register('Language', Language, false)
-    this.container.use(LangAll)
+    this.container.use(LangEn)
     this.container.use(Evaluator)
     this.container.use(Template)
     this.nlp = new Nlp(this.settings)

--- a/nlp/sentiment-analyzer.js
+++ b/nlp/sentiment-analyzer.js
@@ -24,13 +24,13 @@
 const {
   SentimentAnalyzer: SentimentAnalyzerBase
 } = require('@nlpjs/sentiment')
-const { LangAll } = require('@nlpjs/lang-all')
+const { LangEn } = require('@nlpjs/lang-en');
 const { Nlu } = require('@nlpjs/nlu')
 
 class SentimentAnalyzer extends SentimentAnalyzerBase {
   constructor (settings = {}, container) {
     super(settings, container)
-    this.container.use(LangAll)
+    this.container.use(LangEn)
     this.container.use(Nlu)
   }
 

--- a/nlp/sentiment-analyzer.js
+++ b/nlp/sentiment-analyzer.js
@@ -24,7 +24,7 @@
 const {
   SentimentAnalyzer: SentimentAnalyzerBase
 } = require('@nlpjs/sentiment')
-const { LangEn } = require('@nlpjs/lang-en');
+const { LangEn } = require('@nlpjs/lang-en')
 const { Nlu } = require('@nlpjs/nlu')
 
 class SentimentAnalyzer extends SentimentAnalyzerBase {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@nlpjs/core-loader": "^4.4.0",
     "@nlpjs/evaluator": "^4.4.0",
-    "@nlpjs/lang-all": "^4.4.0",
+    "@nlpjs/lang-en": "^4.4.0",
     "@nlpjs/language": "^4.3.0",
     "@nlpjs/nlp": "^4.4.0",
     "@nlpjs/nlu": "^4.4.0",


### PR DESCRIPTION
This improved the start up time quite a bit.
A lot of time is currently spend loading all the locals.

For me this brings down JuiceShop start time locally from `1.27s` to `1.03s` (mean over 100 starts, I modified the server to exit directly after a successful start)

<img width="800" alt="Screenshot 2023-06-24 at 21 36 12" src="https://github.com/juice-shop/juicy-chat-bot/assets/13718901/3ae43c38-abd7-492c-b9ab-f75a698bd761">

<img width="800" alt="Screenshot 2023-06-24 at 21 25 28" src="https://github.com/juice-shop/juicy-chat-bot/assets/13718901/aa58ab8f-82bc-4cd7-8135-09c8f18d4b97">

Other languages are not supported by juice-shop, so its probably not worth having them supported by juicy-chat-bot.